### PR TITLE
fix: incorrect example in isSameLength

### DIFF
--- a/src/arrays-tasks.js
+++ b/src/arrays-tasks.js
@@ -130,7 +130,7 @@ function getAverage(/* arr */) {
  * @return {boolean} - True if all strings have the same length, false otherwise.
  *
  * @example
- *    isSameLength(['apple', 'banana', 'cherry']) => true
+ *    isSameLength(['orange', 'banana', 'cherry']) => true
  *    isSameLength(['cat', 'dog', 'elephant']) => false
  */
 function isSameLength(/* arr */) {


### PR DESCRIPTION
This example is incorrect. Should return false.
Changed fruit to 'orange' (6 letters)