### PR TITLE
Fix: update ecmaVersion in ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
     SharedArrayBuffer: 'readonly',
   },
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2022,
   },
   rules: {
     'prettier/prettier': [


### PR DESCRIPTION
# Fix: update ecmaVersion in ESLint config

## Description

`ecmaVersion` in `ESLint` config should be updated. Currently it set to `2018` and newer JS features such as `nullish coalescing operator` are forbidden by the linter.

Because of this inconvenience students are forced to write their solutions like this:

```js
const value1 = arr1[index] !== undefined ? arr1[index] : 0;
const value2 = arr2[index] !== undefined ? arr2[index] : 0;
```

But in 2024 they should be able to just do:

```js
const value1 = arr1[index] ?? 0;
const value2 = arr2[index] ?? 0;
```